### PR TITLE
Minor fixes to build and fixed bug with SendMessage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ ELSEIF(UNIX)
 ENDIF(WIN32)
 
 #Find Boost
-find_package(Boost 1.58 COMPONENTS system filesystem REQUIRED)
+find_package(Boost 1.58 COMPONENTS system filesystem date_time REQUIRED)
 IF(Boost_FOUND)
   include_directories(${Boost_INCLUDE_DIRS})
   target_link_libraries(revengeMusic ${Boost_LIBRARIES})

--- a/src/MessageQueue.cpp
+++ b/src/MessageQueue.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/interprocess/detail/os_file_functions.hpp>
 #include <boost/interprocess/ipc/message_queue.hpp>
+#include "boost/date_time/posix_time/posix_time.hpp"
 
 #include <iostream>
 #include <string>
@@ -101,7 +102,7 @@ bool MessageQueue::GetMessage(std::string& msg, message_queue::size_type recvd_s
 
 bool MessageQueue::SendMessage(const char* msg) {
     try {
-        queue->send(msg, std::strlen(msg), 0);
+        queue->send(msg, std::strlen(msg)+1, 0);
     }
     catch(interprocess_exception &ex) {
         message_queue::remove(queue_name);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,8 @@
   #include <Knownfolders.h>
   #include <Shlobj.h>
   #include <cwchar>
+  #undef GetMessage
+  #undef SendMessage
 #else
   #ERROR "Incompatible OS"
 #endif


### PR DESCRIPTION
Added date_time to COMPONENTS when using find_package for Boost. 
# undef GetMessage and SendMessage for windows because windows.h redefines those two names.

Fixed SendMessage by specifying the length of the buffer as strlen()+1 for the null byte.
